### PR TITLE
64 settings voice announcements announce avg speed at end of each run

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -84,6 +84,7 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
             Pair<Track, Pair<TrackPoint, SensorDataSet>> data = trackRecordingManager.getDataForUI();
 
             voiceAnnouncementManager.announceStatisticsIfNeeded(data.first);
+            voiceAnnouncementManager.announceAfterRun(data.first);
 
             recordingDataObservable.postValue(new RecordingData(data.first, data.second.first, data.second.second));
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -137,8 +137,21 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
             return;
         }
 
-        //TODO: Once we have run data from other groups, only call this if we're at the end of a run
-        voiceAnnouncement.announce(VoiceAnnouncementUtils.createRunStatistics(context, track.getTrackStatistics(), PreferencesUtils.getUnitSystem()));
+        boolean announce = false;
+        this.trackStatistics = track.getTrackStatistics();
+        if (trackStatistics.getTotalDistance().greaterThan(nextTotalDistance)) {
+            updateNextTaskDistance();
+            announce = true;
+        }
+        if (!trackStatistics.getTotalTime().minus(nextTotalTime).isNegative()) {
+            updateNextDuration();
+            announce = true;
+        }
+
+        if (announce) {
+            //TODO: Once we have run data from other groups, change the conditions to only call this if we're at the end of a run
+            voiceAnnouncement.announce(VoiceAnnouncementUtils.createRunStatistics(context, track.getTrackStatistics(), PreferencesUtils.getUnitSystem()));
+        }
     }
 
     public void announceStatisticsIfNeeded(@NonNull Track track) {

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -131,6 +131,16 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
     }
 
+
+    public void announceAfterRun(@NonNull Track track) {
+        if (shouldNotAnnounce()) {
+            return;
+        }
+
+        //TODO: Once we have run data from other groups, only call this if we're at the end of a run
+        voiceAnnouncement.announce(VoiceAnnouncementUtils.createRunStatistics(context, track.getTrackStatistics(), PreferencesUtils.getUnitSystem()));
+    }
+
     public void announceStatisticsIfNeeded(@NonNull Track track) {
         if (shouldNotAnnounce()) {
             return;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,7 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
-import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAvgSpeed;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAverageSpeed;
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -87,6 +87,46 @@ class VoiceAnnouncementUtils {
 
 
         return builder;
+    }
+
+    static Spannable createRunStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
+        SpannableStringBuilder builder = new SpannableStringBuilder();
+        //TODO: Once we get run data from other groups, we can announce run statistics instead of track statistics
+        Distance totalDistance = trackStatistics.getTotalDistance();
+        Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
+
+        int speedId;
+        String unitSpeedTTS;
+        switch (unitSystem) {
+            case METRIC -> {
+                speedId = R.string.voiceSpeedKilometersPerHourPlural;
+                unitSpeedTTS = "kilometer per hour";
+            }
+            case IMPERIAL_FEET, IMPERIAL_METER -> {
+                speedId = R.string.voiceSpeedMilesPerHourPlural;
+                unitSpeedTTS = "mile per hour";
+            }
+            case NAUTICAL_IMPERIAL -> {
+                speedId = R.string.voiceSpeedMKnotsPlural;
+                unitSpeedTTS = "knots";
+            }
+            default -> throw new RuntimeException("Not implemented");
+        }
+
+        if (totalDistance.isZero()) {
+            return builder;
+        }
+
+        //Announce Average Speed
+       if (shouldVoiceAnnounceRunAverageSpeed()) {
+           double speedInUnit = averageMovingSpeed.to(unitSystem);
+           builder.append(" ")
+                   .append(context.getString(R.string.speed));
+           String template = context.getResources().getString(speedId);
+           appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
+           builder.append(".");
+       }
+       return builder;
     }
 
     static Spannable createStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem, boolean isReportSpeed, @Nullable IntervalStatistics.Interval currentInterval, @Nullable SensorStatistics sensorStatistics) {

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,6 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAvgSpeed;
 
 import android.content.Context;
 import android.icu.text.MessageFormat;

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -440,6 +440,15 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_average_heart_rate_key, value);
     }
 
+    public static boolean shouldVoiceAnnounceRunAverageSpeed() {
+        return getBoolean(R.string.voice_announce_run_average_speed_key, true);
+    }
+
+    @VisibleForTesting
+    public static void setVoiceAnnounceRunAverageSpeed(boolean value) {
+        setBoolean(R.string.voice_announce_run_average_speed_key, value);
+    }
+
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));
     }

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -256,6 +256,9 @@
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
 
+    <string name="voice_announce_run_average_speed_key" translatable="false">voiceAnnounceRunAverageSpeed</string>
+    <bool name="voice_announce_run_average_speed_default" translatable="false">false</bool>
+
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -411,6 +411,7 @@ limitations under the License.
     <string name="settings_announcements_lap_heart_rate">Lap heart rate</string>
     <string name="settings_announcements_average_speed_pace">Average speed/pace</string>
     <string name="settings_announcements_lap_speed_pace">Lap speed/pace</string>
+    <string name="settings_announcements_run_average_speed">Run Average Speed</string>
 
     <!-- Custom Layout -->
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -361,6 +361,7 @@ limitations under the License.
     <string name="settings_announcements_summary">Time, Distance, Voice Speed</string>
 
     <string name="settings_announcements_recording_title">Announcements After Recording</string>
+    <string name="settings_announcements_run_title">Announcements After Run</string>
 
     <string name="settings_import_export_title">Import/Export</string>
     <string name="settings_import_export_summary">Import, Export, Auto Export</string>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -68,11 +68,6 @@
             android:defaultValue="@bool/voice_announce_lap_heart_rate_default"
             android:key="@string/voice_announce_lap_heart_rate_key"
             android:title="@string/settings_announcements_lap_heart_rate" />
-
-        <SwitchPreferenceCompat
-            android:defaultValue="@bool/voice_announce_run_avg_speed_default"
-            android:key="@string/voice_announce_run_average_speed_key"
-            android:title="@string/settings_announcements_run_average_speed" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_announcements_recording_title">
@@ -80,5 +75,12 @@
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:key="@string/voice_announce_max_speed_recording_key"
             android:title="@string/settings_announcements_max_speed_recording" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_announcements_run_title">
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_run_average_speed_default"
+            android:key="@string/voice_announce_run_average_speed_key"
+            android:title="@string/settings_announcements_run_average_speed" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -68,6 +68,11 @@
             android:defaultValue="@bool/voice_announce_lap_heart_rate_default"
             android:key="@string/voice_announce_lap_heart_rate_key"
             android:title="@string/settings_announcements_lap_heart_rate" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_run_avg_speed_default"
+            android:key="@string/voice_announce_run_average_speed_key"
+            android:title="@string/settings_announcements_run_average_speed" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
**Describe the pull request**
On the front-end, a preference category has been added to group announcements related to runs, and a switch for announcing run average speed was also added.

Run Statistics are not available to us from other groups yet, so the logic for this is partially complete. 
The average speed from TrackStatistics is temporarily being used instead.

**Link to the the issue**
https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/64

