### PR TITLE
97 settings voice announcements announce max slope at end of each recording.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -124,12 +124,15 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
 
         // add other check with and here
-        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording()) {
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() ) {
             return;
         }
 
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
+        voiceAnnouncement.announce(VoiceAnnouncementUtils.calculateMaxSlope());
+        
     }
+   
 
     public void announceStatisticsIfNeeded(@NonNull Track track) {
         if (shouldNotAnnounce()) {

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -129,7 +129,7 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
 
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
-        voiceAnnouncement.announce(VoiceAnnouncementUtils.calculateMaxSlope());
+        
         
     }
    

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,6 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -33,6 +34,12 @@ import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
 class VoiceAnnouncementUtils {
 
     private VoiceAnnouncementUtils() {
+    }
+    
+    static double calculateMaxSlope() {
+       
+        // This method should return the calculated maximum slope.
+           return 0.0; 
     }
 
     static Spannable createIdle(Context context) {
@@ -203,6 +210,17 @@ class VoiceAnnouncementUtils {
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
         }
+        if (shouldVoiceAnnounceMaxSlope()) {
+            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(maxSlope)) {
+                builder.append(" ")
+               .append(context.getString(R.string.settings_announcements_max_slope))
+               .append(": ")
+               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
+               .append(".");
+            }
+        }
+
 
         return builder;
     }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,7 +7,6 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
-import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope; 
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -203,16 +202,6 @@ class VoiceAnnouncementUtils {
                     .append(context.getString(R.string.current_heart_rate));
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
-        }
-        if (shouldVoiceAnnounceMaxSlope()) {
-            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
-            if (!Double.isNaN(maxSlope)) {
-                builder.append(" ")
-               .append(context.getString(R.string.max_slope))
-               .append(": ")
-               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
-               .append(".");
-            }
         }
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -91,6 +91,17 @@ class VoiceAnnouncementUtils {
             builder.append(".");
         }
 
+        if (shouldVoiceAnnounceMaxSlope()) {
+            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(maxSlope)) {
+                builder.append(" ")
+               .append(context.getString(R.string.settings_announcements_max_slope))
+               .append(": ")
+               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
+               .append(".");
+            }
+        }
+       
 
         return builder;
     }
@@ -210,16 +221,7 @@ class VoiceAnnouncementUtils {
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
         }
-        if (shouldVoiceAnnounceMaxSlope()) {
-            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
-            if (!Double.isNaN(maxSlope)) {
-                builder.append(" ")
-               .append(context.getString(R.string.settings_announcements_max_slope))
-               .append(": ")
-               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
-               .append(".");
-            }
-        }
+        
 
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,6 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope; 
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -202,6 +203,16 @@ class VoiceAnnouncementUtils {
                     .append(context.getString(R.string.current_heart_rate));
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
+        }
+        if (shouldVoiceAnnounceMaxSlope()) {
+            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(maxSlope)) {
+                builder.append(" ")
+               .append(context.getString(R.string.max_slope))
+               .append(": ")
+               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
+               .append(".");
+            }
         }
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -439,7 +439,14 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceAverageHeartRate(boolean value) {
         setBoolean(R.string.voice_announce_average_heart_rate_key, value);
     }
-
+    public static boolean shouldVoiceAnnounceMaxSlope() {
+        return getBoolean(R.string.voice_announce_max_slope_key, true);
+    }
+    
+    @VisibleForTesting
+    public static void setVoiceAnnounceMaxSlope(boolean value) {
+        setBoolean(R.string.voice_announce_max_slope_key, value);
+    }
     // recoding related setting helper methods
     public static boolean shouldVoiceAnnounceMaxSpeedRecording() {
         return getBoolean(R.string.voice_announce_max_speed_recording_key, true);

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -255,7 +255,8 @@
     <bool name="voice_announce_average_heart_rate_default" translatable="false">false</bool>
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
-
+    <string name="voice_announce_max_slope_key">voiceAnnounceMaxSlope</string>
+    <bool name="voice_announce_max_slope_default" translatable="false">true</bool>
     <!-- Recording related data -->
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -413,6 +413,7 @@ limitations under the License.
     <string name="settings_announcements_lap_heart_rate">Lap heart rate</string>
     <string name="settings_announcements_average_speed_pace">Average speed/pace</string>
     <string name="settings_announcements_lap_speed_pace">Lap speed/pace</string>
+    <string name="settings_announcements_max_slope">Max slope</string>
 
     <!-- Recording Related Data -->
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -75,5 +75,10 @@
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:key="@string/voice_announce_max_speed_recording_key"
             android:title="@string/settings_announcements_max_speed_recording" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_max_slope_default"
+            android:key="@string/voice_announce_max_slope_key"
+            android:title="@string/settings_announcements_max_slope" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This pull request introduces the feature to announce the maximum slope at the end of each recording. Previously, the maximum slope was not announced. With this enhancement, users will now receive voice announcements regarding the maximum slope based on elevation data at the conclusion of their recordings. However, the implementation is not yet fully completed as it requires collecting data from other groups.

issue: #97


