### PR TITLE
71 settings voice announcements announce avg slope at end of each recording

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/announcement/TTSManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/TTSManager.java
@@ -154,24 +154,26 @@ public class TTSManager {
     public void stop() {
         // Shutdown the TextToSpeech engine after the current task is done
         if (tts != null) {
-            while (tts.isSpeaking()) {
-                try {
-                    Thread.sleep(200);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+            Thread stopTTs = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    // Wait until the speaking task is completed
+                    while (tts.isSpeaking()) {
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    // Shutdown the TextToSpeech engine after the current task is done
+                    tts.shutdown();
+                    tts = null;
                 }
-            }
+            });
 
-            tts.shutdown();
-            tts = null;
-        }
-
-        if (ttsFallback != null) {
-            ttsFallback.release();
-            ttsFallback = null;
+            stopTTs.start();
         }
     }
-
     private void onTtsReady() {
         Locale locale = Locale.getDefault();
         int languageAvailability = tts.isLanguageAvailable(locale);

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -122,15 +122,11 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         if (shouldNotAnnounce()) {
             return;
         }
-
         // add other check with and here
-        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() ) {
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() && !PreferencesUtils.shouldVoiceAnnounceAveragesloperecording()  ) {
             return;
         }
-
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
-        
-        
     }
    
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -41,7 +41,7 @@ class VoiceAnnouncementUtils {
         // This method should return the calculated maximum slope.
            return 0.0; 
     }
-    static double CalculateAvergeaSlope(){
+    static double CalculateAverageSlope(){
         // This is dummy methods to fetch or calculate the average slope.
         return 10.0;
     }
@@ -106,11 +106,10 @@ class VoiceAnnouncementUtils {
             }
         }
             if (shouldVoiceAnnounceAveragesloperecording()) {
-                double avgSlope = calculateMaxSlope();
+                double avgSlope = CalculateAverageSlope();
                 if (!Double.isNaN(avgSlope)) {
                     builder.append(" ")
                             .append("Average slope")
-                            .append(" ")
                             .append(": ")
                             .append(String.format("%.2f%%", avgSlope))
                             .append(".");

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -8,7 +8,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
-
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAveragesloperecording;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
 import android.content.Context;
@@ -40,6 +40,10 @@ class VoiceAnnouncementUtils {
        
         // This method should return the calculated maximum slope.
            return 0.0; 
+    }
+    static double CalculateAvergeaSlope(){
+        // This is dummy methods to fetch or calculate the average slope.
+        return 10.0;
     }
 
     static Spannable createIdle(Context context) {
@@ -101,8 +105,17 @@ class VoiceAnnouncementUtils {
                .append(".");
             }
         }
-       
-
+            if (shouldVoiceAnnounceAveragesloperecording()) {
+                double avgSlope = calculateMaxSlope();
+                if (!Double.isNaN(avgSlope)) {
+                    builder.append(" ")
+                            .append("Average slope")
+                            .append(" ")
+                            .append(": ")
+                            .append(String.format("%.2f%%", avgSlope))
+                            .append(".");
+                }
+            }
         return builder;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -456,6 +456,14 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceMaxSpeedRecording(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
+    //recording related data for average slope's helper methods
+    public static boolean shouldVoiceAnnounceAveragesloperecording() {
+        return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
+    }
+    @VisibleForTesting
+    public static void setVoiceAnnounceAveragesloperecording(boolean value) {
+        setBoolean(R.string.voice_announce_average_slope_recording_key, value);
+    }
 
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -262,23 +262,24 @@
 
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
-    <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
 
+    <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
     <bool name="voice_announce_average_slope_recording_default" translatable="false">true</bool>
-    <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
+
   
   
   
     <!-- Run related data -->
+
     <string name="voice_announce_run_average_speed_key" translatable="false">voiceAnnounceRunAverageSpeed</string>
     <bool name="voice_announce_run_average_speed_default" translatable="false">false</bool>
 
 
-    <string name="voice_announce_max_slope_key">voiceAnnounceMaxSlope</string>
-    <bool name="voice_announce_max_slope_default" translatable="false">true</bool>
+
   
   
     <!-- See TrackFileFormat -->
+    <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>
 
     <string name="import_prevent_reimport_key" translatable="false">preventReimportTrackKey</string>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -255,12 +255,14 @@
     <bool name="voice_announce_average_heart_rate_default" translatable="false">false</bool>
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
+    <!-- Recording related data -->
     <string name="voice_announce_max_slope_key">voiceAnnounceMaxSlope</string>
     <bool name="voice_announce_max_slope_default" translatable="false">true</bool>
-    <!-- Recording related data -->
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
+    <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
 
+    <bool name="voice_announce_average_slope_recording_default" translatable="false">true</bool>
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -417,8 +417,9 @@ limitations under the License.
 
     <!-- Recording Related Data -->
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
+    <!-- Recording Related Data -->
+    <string name="settings_announcements_average_slope_recording">Average slope</string>
 
-    <!-- Custom Layout -->
 
 
     <string name="custom_layout_list_title">Layouts</string>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -80,5 +80,12 @@
             android:defaultValue="@bool/voice_announce_max_slope_default"
             android:key="@string/voice_announce_max_slope_key"
             android:title="@string/settings_announcements_max_slope" />
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/voice_announce_max_slope_default"
+            android:title="@string/settings_announcements_average_slope_recording"
+            app:key="@string/voice_announce_average_slope_recording_key" />
+
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Issue: voice annoucement for average slope at the end of recording.

Impact: Enchancement of app by addition of metric for annoucement.

Solution: Added a button in the settings to enable and disable the average slope announcement.

Benefit: enhancement of voice announcement feature.

issue: [rilling#71](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/71#issue-2189267524)
