### PR TITLE
116 settings voice announce for total time skied at end of the recording

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -124,7 +124,7 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
 
         // add other check with and here
-        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording()) {
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceTimeSkiedRecording()) {
             return;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -5,6 +5,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAverageSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapHeartRate;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTimeSkiedRecording;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 
@@ -91,14 +92,17 @@ class VoiceAnnouncementUtils {
             builder.append(".");
         }
 		
-		if(shouldVoiceAnnounceTimeSkiedRecording()) {
-			Duration movingTime = trackStatistics.getMovingTime();
-//			Duration movingTime = 10000;
-        if (shouldVoiceAnnounceMovingTime() && !movingTime.isZero()) {
-            appendDuration(context, builder, movingTime);
-            builder.append(".");
+
+        if (shouldVoiceAnnounceTimeSkiedRecording()) {
+            double timeSkied = calculateTimeSkied(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(timeSkied)) {
+                builder.append(" ")
+                        .append(context.getString(R.string.settings_announcements_time_skied_recording))
+                        .append(": ")
+                        .append(String.format("%.2f%%", timeSkied)) // Format the slope value
+                        .append(".");
+            }
         }
-		}
 
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -36,7 +36,13 @@ class VoiceAnnouncementUtils {
     private VoiceAnnouncementUtils() {
     }
 
-    static Spannable createIdle(Context context) {
+    static double calculateTimeSkied() {
+
+           return 0.0; 
+		   
+    }
+	
+	static Spannable createIdle(Context context) {
         return new SpannableStringBuilder()
                 .append(context.getString(R.string.voiceIdle));
     }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -9,6 +9,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTimeSkiedRecording;
 
 import android.content.Context;
 import android.icu.text.MessageFormat;
@@ -83,6 +84,15 @@ class VoiceAnnouncementUtils {
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
         }
+		
+		if(shouldVoiceAnnounceTimeSkiedRecording()) {
+			Duration movingTime = trackStatistics.getMovingTime();
+//			Duration movingTime = 10000;
+        if (shouldVoiceAnnounceMovingTime() && !movingTime.isZero()) {
+            appendDuration(context, builder, movingTime);
+            builder.append(".");
+        }
+		}
 
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -449,6 +449,16 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceMaxSpeedRecording(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
+	
+	    // recoding related setting helper methods
+    public static boolean shouldVoiceAnnounceTimeSkiedRecording() {
+        return getBoolean(R.string.voice_announce_time_skied_recording_key, true);
+    }
+
+    @VisibleForTesting
+    public static void setVoiceAnnounceTimeSkiedRecording(boolean value) {
+        setBoolean(R.string.voice_announce_time_skied_recording_key, value);
+    }
 
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -450,9 +450,14 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
 	
-	    // recoding related setting helper methods
+	// recoding related setting helper methods
     public static boolean shouldVoiceAnnounceTimeSkiedRecording() {
         return getBoolean(R.string.voice_announce_time_skied_recording_key, true);
+    }
+	
+	@VisibleForTesting
+    public static void setVoiceAnnounceTimeSkiedRecording(boolean value) {
+        setBoolean(R.string.voice_announce_time_skied_recording_key, value);
     }
 
     @VisibleForTesting

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -460,10 +460,6 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_time_skied_recording_key, value);
     }
 
-    @VisibleForTesting
-    public static void setVoiceAnnounceTimeSkiedRecording(boolean value) {
-        setBoolean(R.string.voice_announce_time_skied_recording_key, value);
-    }
 
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -259,6 +259,10 @@
     <!-- Recording related data -->
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
+	
+	<!-- Recording related data -->
+    <string name="voice_announce_time_skied_recording_key">voiceAnnounceTimeSkiedRecording</string>
+    <bool name="voice_announce_time_skied_recording_default" translatable="false">true</bool>
 
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -416,7 +416,7 @@ limitations under the License.
 
     <!-- Recording Related Data -->
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
-
+	<string name="settings_announcements_time_skied_recording">Time skied/recording</string>
     <!-- Custom Layout -->
 
 

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -75,5 +75,10 @@
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:key="@string/voice_announce_max_speed_recording_key"
             android:title="@string/settings_announcements_max_speed_recording" />
+			
+		<SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_time_skied_recording_default"
+            android:key="@string/voice_announce_time_skied_recording_key"
+            android:title="@string/settings_announcements_time_skied_recording" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -78,13 +78,13 @@
             android:title="@string/settings_announcements_max_speed_recording" />
 
 			
-		    <SwitchPreferenceCompat
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_time_skied_recording_default"
             android:key="@string/voice_announce_time_skied_recording_key"
             android:title="@string/settings_announcements_time_skied_recording" />
 
 
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:title="@string/settings_announcements_average_speed_recording"
             app:key="@string/voice_announce_average_speed_recording_key" />
@@ -93,9 +93,8 @@
             android:defaultValue="@bool/voice_announce_max_slope_default"
             android:key="@string/voice_announce_max_slope_key"
             android:title="@string/settings_announcements_max_slope" />
-        <SwitchPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_max_slope_default"
             android:title="@string/settings_announcements_average_slope_recording"
             app:key="@string/voice_announce_average_slope_recording_key" />
@@ -107,9 +106,7 @@
             android:defaultValue="@bool/voice_announce_run_average_speed_default"
             android:key="@string/voice_announce_run_average_speed_key"
             android:title="@string/settings_announcements_run_average_speed" />
-        <SwitchPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_average_slope_run_default"
             android:title="@string/settings_announcements_average_slope_run"
             app:key="@string/voice_announce_average_slope_run_key" />


### PR DESCRIPTION
https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/116

**Describe the pull request**
116 settings voice announce for total time skied at end of the recording. 

This functionality seeks to improve user experience by offering voice announcements for the total skiing duration at the conclusion of a recording session within the settings menu.

**Link to the the issue**
116
