### PR TITLE
70 settings voice announcements announce avg slope at end of each run

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -11,7 +11,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAverageSpeed;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAveragesloperecording;
-
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAverageslopeRun;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
 import android.content.Context;
@@ -127,7 +127,6 @@ class VoiceAnnouncementUtils {
         Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
         Speed maxSpeed = trackStatistics.getMaxSpeed();
-
         int speedId;
         String unitSpeedTTS;
         switch (unitSystem) {
@@ -165,6 +164,16 @@ class VoiceAnnouncementUtils {
             String template = context.getResources().getString(speedId);
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
+        }
+        if (shouldVoiceAnnounceAverageslopeRun()) {
+            double avgSlope = CalculateAverageSlope();
+            if (!Double.isNaN(avgSlope)) {
+                builder.append(" ")
+                        .append("Average slope")
+                        .append(": ")
+                        .append(String.format("%.2f%%", avgSlope))
+                        .append(".");
+            }
         }
         return builder;
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -445,6 +445,7 @@ public class PreferencesUtils {
         return getBoolean(R.string.voice_announce_max_speed_run_key, true);
     }
 
+
     @VisibleForTesting
     public static void setVoiceAnnounceMaxSpeedRun(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_run_key, value);
@@ -478,12 +479,21 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceMaxSpeedRecording(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
-    //recording related data for average slope's helper methods
+    //recording related data for average slope's helper methods for each recording
     public static boolean shouldVoiceAnnounceAveragesloperecording() {
         return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
     }
     @VisibleForTesting
     public static void setVoiceAnnounceAveragesloperecording(boolean value) {
+        setBoolean(R.string.voice_announce_average_slope_recording_key, value);
+
+    }
+    //recording related data for average slope's helper methods for each run
+    public static boolean shouldVoiceAnnounceAverageslopeRun() {
+        return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
+    }
+    @VisibleForTesting
+    public static void setVoiceAnnounceAverageslopeRun(boolean value) {
         setBoolean(R.string.voice_announce_average_slope_recording_key, value);
 
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -490,11 +490,11 @@ public class PreferencesUtils {
     }
     //recording related data for average slope's helper methods for each run
     public static boolean shouldVoiceAnnounceAverageslopeRun() {
-        return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
+        return getBoolean(R.string.voice_announce_average_slope_run_key, true);
     }
     @VisibleForTesting
     public static void setVoiceAnnounceAverageslopeRun(boolean value) {
-        setBoolean(R.string.voice_announce_average_slope_recording_key, value);
+        setBoolean(R.string.voice_announce_average_slope_run_key, value);
 
     }
 

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -267,6 +267,8 @@
     <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
     <bool name="voice_announce_average_slope_recording_default" translatable="false">true</bool>
 
+    <string name="voice_announce_average_slope_run_key">voiceAnnounceAverageSlopeRun</string>
+    <bool name="voice_announce_average_slope_run_default" translatable="false">true</bool>
   
   
   

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -423,7 +423,7 @@ limitations under the License.
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
     <string name="settings_announcements_max_slope">Max slope</string>
     <string name="settings_announcements_average_slope_recording">Average slope</string>
-
+    <string name="settings_announcements_average_slope_run">Average slope</string>
 
 
 

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -95,6 +95,12 @@
             android:defaultValue="@bool/voice_announce_run_average_speed_default"
             android:key="@string/voice_announce_run_average_speed_key"
             android:title="@string/settings_announcements_run_average_speed" />
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/voice_announce_average_slope_run_default"
+            android:title="@string/settings_announcements_average_slope_run"
+            app:key="@string/voice_announce_average_slope_run_key" />
         <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_max_speed_run_default"
             android:key="@string/voice_announce_max_speed_run_key"


### PR DESCRIPTION
-The user will be able to enable/Disable the Voice Announcement of Average Slope at the end of recording

Description:
- Created a radio button "Average Slope" to enable and disable announcement.
- Created  under  " Announcements After run" Section in "Settings_announcements".
- Created helper methods for average slope value for the run.

Issue [#15  ](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/70)
