### PR TITLE
98 settings voice announcements announce total waiting time at end of each recording

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -13,9 +13,9 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAveragesloperecording;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
-import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTimeSkiedRecording;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAverageSpeedRecording;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAverageslopeRun;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalWaitingTime;
 
 
 import android.content.Context;
@@ -64,7 +64,7 @@ class VoiceAnnouncementUtils {
     }
     
     // Method to calculate total waiting time
-    public long calculateTotalWaitingTime(EnhancedTrackStatistics stats) {
+    public static long calculateTotalWaitingTime(EnhancedTrackStatistics stats) {
         // Get the waiting time for chairlift from EnhancedTrackStatistics
         return stats.getWaitingTimeForChairlift();
     }
@@ -80,7 +80,7 @@ class VoiceAnnouncementUtils {
         Speed maxSpeed = trackStatistics.getMaxSpeed();
         Speed avgSpeed = trackStatistics.getAverageSpeed();
 
-        
+        Duration waitingTime = trackStatistics.getTotalChairliftWaitingTime();
     
 
         int perUnitStringId;
@@ -168,6 +168,23 @@ class VoiceAnnouncementUtils {
                         .append(".");
             }
         }
+
+        if (shouldVoiceAnnounceTotalWaitingTime()){
+            long waitingTimeLong=waitingTime.toSeconds();
+            long waitingMinutes=waitingTimeLong%60;
+            long waitingSeconds=waitingTimeLong/60;
+            builder.append(" ")
+                    .append(context.getString(R.string.settings_announcements_total_waiting_time))
+                    .append(": ");
+            if (waitingMinutes>0){
+                builder.append(waitingMinutes+" ");
+            }
+            if (waitingSeconds>0){
+                builder.append(waitingSeconds+" ");
+            }
+            builder.append(waitingTimeLong+".");
+        }
+
         return builder;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -85,8 +85,8 @@ class VoiceAnnouncementUtils {
         Speed maxSpeed = trackStatistics.getMaxSpeed();
         Speed avgSpeed = trackStatistics.getAverageSpeed();
 
-        long startTime = ...; // Provide the start time in milliseconds
-        long endTime = ...; // Provide the end time in milliseconds
+        long startTime = System.currentTimeMillis(); // Provide the start time in milliseconds
+        long endTime = startTime + (5 * 60 * 1000); // Provide the end time in milliseconds
 
         // Calculate waiting time using the calculateWaitingTime method
         double waitingTime = calculateWaitingTime(startTime, endTime);

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -61,6 +61,18 @@ class VoiceAnnouncementUtils {
         // This is dummy methods to fetch or calculate the average slope.
         return 10.0;
     }
+    public static double calculateWaitingTime(long startTime, long endTime) {
+        // Ensure start time is before end time
+        if (startTime > endTime) {
+            throw new IllegalArgumentException("Start time cannot be after end time.");
+        }
+
+        // Calculate the waiting time in milliseconds
+        long waitingTimeInMillis = endTime - startTime;
+        // Convert waiting time to minutes
+        double waitingTimeInMinutes = waitingTimeInMillis / (60.0 * 1000.0);
+        return waitingTimeInMinutes;
+    }
 
 
     static Spannable createIdle(Context context) {
@@ -72,6 +84,15 @@ class VoiceAnnouncementUtils {
         SpannableStringBuilder builder = new SpannableStringBuilder();
         Speed maxSpeed = trackStatistics.getMaxSpeed();
         Speed avgSpeed = trackStatistics.getAverageSpeed();
+
+        long startTime = ...; // Provide the start time in milliseconds
+        long endTime = ...; // Provide the end time in milliseconds
+
+        // Calculate waiting time using the calculateWaitingTime method
+        double waitingTime = calculateWaitingTime(startTime, endTime);
+        // Example usage of waitingTime
+        builder.append("Waiting time: ").append(String.valueOf(waitingTime)).append(" minutes. ");
+    
 
         int perUnitStringId;
         int distanceId;
@@ -123,6 +144,7 @@ class VoiceAnnouncementUtils {
                         .append(".");
             }
         }
+        
 
         if (shouldVoiceAnnounceAverageSpeedRecording()) {
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -37,6 +37,7 @@ import de.dennisguse.opentracks.settings.UnitSystem;
 import de.dennisguse.opentracks.stats.SensorStatistics;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
+import de.dennisguse.opentracks.stats.EnhancedTrackStatistics;
 
 class VoiceAnnouncementUtils {
 
@@ -61,17 +62,11 @@ class VoiceAnnouncementUtils {
         // This is dummy methods to fetch or calculate the average slope.
         return 10.0;
     }
-    public static double calculateWaitingTime(long startTime, long endTime) {
-        // Ensure start time is before end time
-        if (startTime > endTime) {
-            throw new IllegalArgumentException("Start time cannot be after end time.");
-        }
-
-        // Calculate the waiting time in milliseconds
-        long waitingTimeInMillis = endTime - startTime;
-        // Convert waiting time to minutes
-        double waitingTimeInMinutes = waitingTimeInMillis / (60.0 * 1000.0);
-        return waitingTimeInMinutes;
+    
+    // Method to calculate total waiting time
+    public long calculateTotalWaitingTime(EnhancedTrackStatistics stats) {
+        // Get the waiting time for chairlift from EnhancedTrackStatistics
+        return stats.getWaitingTimeForChairlift();
     }
 
 
@@ -85,13 +80,7 @@ class VoiceAnnouncementUtils {
         Speed maxSpeed = trackStatistics.getMaxSpeed();
         Speed avgSpeed = trackStatistics.getAverageSpeed();
 
-        long startTime = System.currentTimeMillis(); // Provide the start time in milliseconds
-        long endTime = startTime + (5 * 60 * 1000); // Provide the end time in milliseconds
-
-        // Calculate waiting time using the calculateWaitingTime method
-        double waitingTime = calculateWaitingTime(startTime, endTime);
-        // Example usage of waitingTime
-        builder.append("Waiting time: ").append(String.valueOf(waitingTime)).append(" minutes. ");
+        
     
 
         int perUnitStringId;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -23,7 +23,6 @@ import android.icu.text.MessageFormat;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.style.TtsSpan;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -38,7 +37,7 @@ import de.dennisguse.opentracks.settings.UnitSystem;
 import de.dennisguse.opentracks.stats.SensorStatistics;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
-import de.dennisguse.opentracks.stats.EnhancedTrackStatistics;
+
 
 class VoiceAnnouncementUtils {
     private static Double currentMaxSlope;
@@ -64,12 +63,8 @@ class VoiceAnnouncementUtils {
         // This is dummy methods to fetch or calculate the average slope.
         return 10.0;
     }
-    
-    // Method to calculate total waiting time
-    public static long calculateTotalWaitingTime(EnhancedTrackStatistics stats) {
-        // Get the waiting time for chairlift from EnhancedTrackStatistics
-        return stats.getWaitingTimeForChairlift();
-    }
+
+
 
     private static double calculateAverageSlope(Distance totalDistance, Float altitudeGain, Float altitudeLoss) {
         double avgSlope=0;
@@ -191,12 +186,12 @@ class VoiceAnnouncementUtils {
                     .append(context.getString(R.string.settings_announcements_total_waiting_time))
                     .append(": ");
             if (waitingMinutes>0){
-                builder.append(waitingMinutes+" ");
+                builder.append(waitingMinutes+" minutes ");
             }
             if (waitingSeconds>0){
-                builder.append(waitingSeconds+" ");
+                builder.append(waitingSeconds+" seconds ");
             }
-            builder.append(waitingTimeLong+".");
+            builder.append(".");
         }
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -498,6 +498,16 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_max_slope_key, value);
     }
 
+    public static boolean shouldVoiceAnnounceTotalWaitingTime() {
+        return getBoolean(R.string.voice_announce_total_waiting_time_key, true);
+    }
+    
+    @VisibleForTesting
+    public static void setVoiceAnnounceTotalWaitingTime(boolean value) {
+        setBoolean(R.string.voice_announce_total_waiting_time_key, value);
+    }
+    
+
     // recoding related setting helper methods
     public static boolean shouldVoiceAnnounceMaxSpeedRecording() {
         return getBoolean(R.string.voice_announce_max_speed_recording_key, true);

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
@@ -214,7 +214,7 @@ public class TrackStatisticsUpdater {
         // indicates altitude difference allowed in case of small change elevation change while waiting in queue for chairlift
         final float minimumAltitudeChangeAllowed = 0.2f;
         final float minimumDeviationAllowedFromLowestAltitude = 1f;
-        final int thresholdTrackpointsForNoMovement=5;
+        final int thresholdTrackpointsForNoMovement=1;
 
         float altitudeGain = trackPoint.hasAltitudeGain()? trackPoint.getAltitudeGain(): 0f;
         float altitudeLoss = trackPoint.hasAltitudeLoss()? trackPoint.getAltitudeLoss(): 0f;

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -267,6 +267,10 @@
     <string name="voice_announce_max_slope_key">voiceAnnounceMaxSlope</string>
     <bool name="voice_announce_max_slope_default" translatable="false">true</bool>
 
+    <string name="voice_announce_total_waiting_time_key">voiceAnnounceTotalWaitingTime</string>
+    <bool name="voice_announce_total_waiting_time_default" translatable="false">true</bool>
+
+
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
 	

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -466,6 +466,7 @@ limitations under the License.
     <string name="settings_announcements_average_slope_run">Average slope</string>  
     <string name="settings_announcements_max_speed_run">Max speed/run</string>
     <string name="settings_announcements_run_average_speed">Run Average Speed</string>
+    <string name="settings_announcements_total_waiting_time">Total Waiting Time</string>
 
 
     <!-- Recording Related Data -->

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -114,5 +114,9 @@
             android:defaultValue="@bool/voice_announce_max_speed_run_default"
             android:key="@string/voice_announce_max_speed_run_key"
             android:title="@string/settings_announcements_max_speed_run" />
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_max_speed_run_default"
+            android:key="@string/voice_announce_max_speed_run_key"
+            android:title="@string/settings_announcements_total_waiting_time" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
**Describe the pull request**
This pull request adds a new feature to announce the total waiting time after recording activities. When enabled in the app settings, users will now receive voice announcements regarding their total waiting time during their activity recordings.
Integrated the total waiting time announcement feature into the existing voice announcement system.
Provided appropriate localization and formatting for the voice announcement. 

**Link to the the issue**
#98

