### PR TITLE
64 settings voice announcements announce avg speed at end of each run

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -162,9 +162,9 @@ class VoiceAnnouncementUtils {
 
     static Spannable createRunStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
-        //TODO: Once we get run data from other groups, we can announce run statistics instead of track statistics
+        
         Distance totalDistance = trackStatistics.getTotalDistance();
-        Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
+        Speed averageMovingSpeed = Speed.of(trackStatistics.getAverageSpeedPerRun());
         Speed maxSpeed = trackStatistics.getMaxSpeed();
         int speedId;
         String unitSpeedTTS;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -182,13 +182,20 @@ class VoiceAnnouncementUtils {
         trackStatistics.setMaximumSpeedPerRun(0);
         trackStatistics.setDistanceRun(Distance.of(0));
         trackStatistics.setAltitudeRun(0f);
+        trackStatistics.setTimeRun(Duration.ofSeconds(0));
     }
 
     static Spannable createRunStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
 
-        Distance totalDistance = trackStatistics.getTotalDistance();
-        Speed averageMovingSpeed = Speed.of(trackStatistics.getAverageSpeedPerRun());
+        Distance runDistance = trackStatistics.getDistanceRun();
+        Duration runTime = trackStatistics.getTimeRun();
+        Speed averageMovingSpeed= Speed.of(0);
+        if(runDistance!=null&& runTime!=null){
+            averageMovingSpeed = Speed.of(runDistance,runTime);
+        }
+
+
         Float maxSpeed = trackStatistics.getMaximumSpeedPerRun();
         double averageSlope= calculateAverageSlope(trackStatistics.getDistanceRun(),trackStatistics.getAltitudeRun(),0f);
 

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -77,6 +77,10 @@ public class TrackStatistics {
 
 
 
+    private Duration timeRun;
+
+
+
     /**
      * Total time user spent for waiting for chairlift
      */
@@ -140,6 +144,7 @@ public class TrackStatistics {
          endOfRunCounter=other.endOfRunCounter;
          altitudeRun=other.altitudeRun;
          distanceRun=other.totalDistance;
+         timeRun=other.timeRun;
 
      }
 
@@ -217,8 +222,13 @@ public class TrackStatistics {
         totalChairliftWaitingTime = totalChairliftWaitingTime.plus(other.totalChairliftWaitingTime);
         endOfRunCounter+= other.endOfRunCounter;
 
+        if (other.maximumSpeedPerRun!=null&&other.maximumSpeedPerRun>maximumSpeedPerRun){
+            maximumSpeedPerRun=other.maximumSpeedPerRun;
+        }
+
         altitudeRun += other.altitudeRun;
         distanceRun = distanceRun.plus(other.distanceRun);
+        timeRun= timeRun.plus(other.timeRun);
     }
 
     public boolean isInitialized() {
@@ -240,8 +250,12 @@ public class TrackStatistics {
         setTotalChairliftWaitingTime(Duration.ofSeconds(0));
         resetEndOfRunCounter();
 
+        setMaximumSpeedPerRun(0f);
+
         altitudeRun = 0f;
         setDistanceRun(Distance.of(0));
+
+        setTimeRun(Duration.ofSeconds(0));
 
 
         isIdle = false;
@@ -496,6 +510,15 @@ public class TrackStatistics {
 
     public void addDistanceRun(Distance distance_m) {
         distanceRun = distanceRun.plus(distance_m);
+    }
+
+    public Duration getTimeRun() {
+        return timeRun;
+    }
+
+    public void setTimeRun(Duration timeRun) {
+        this.timeRun = timeRun;
+        Log.d("timeRun",this.timeRun.getSeconds()+"");
     }
 
 

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
@@ -109,6 +109,12 @@ public class TrackStatisticsUpdater {
         // Always update time
         currentSegment.setStopTime(trackPoint.getTime());
         currentSegment.setTotalTime(Duration.between(currentSegment.getStartTime(), trackPoint.getTime()));
+        if(lastTrackPoint!=null){
+            Duration timeBetween=Duration.between(lastTrackPoint.getTime(),trackPoint.getTime());
+            currentSegment.setTimeRun(currentSegment.getTimeRun().plus(timeBetween));
+
+        }
+
 
         // Process sensor data: barometer
         if (trackPoint.hasAltitudeGain()) {
@@ -121,8 +127,8 @@ public class TrackStatisticsUpdater {
 
         if (trackPoint.getSpeed()!=null){
             double currentSpeed=trackPoint.getSpeed().toMPS();
-            if (currentSpeed > trackStatistics.getMaximumSpeedPerRun()){
-                trackStatistics.setMaximumSpeedPerRun(((float) currentSpeed));
+            if (currentSpeed > currentSegment.getMaximumSpeedPerRun()){
+                currentSegment.setMaximumSpeedPerRun(((float) currentSpeed));
             }
         }
         // this function will always be called for all trackpoints to check if it is waiting for chairlift


### PR DESCRIPTION
1. Use run-specific statistics instead of track statistics 