### PR TITLE
70 settings voice announcements announce avg slope at end of each run

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -70,6 +70,8 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
     private IntervalStatistics intervalStatistics;
     private Distance intervalDistance;
 
+    private int lastRunCount=0;
+
     public VoiceAnnouncementManager(@NonNull Context context) {
         this.context = context;
         contentProviderUtils = new ContentProviderUtils(context);
@@ -139,6 +141,16 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
             return;
         }
 
+        int currentRunCount=track.getTrackStatistics().getEndOfRunCounter();
+        int lastRunCount=this.lastRunCount;
+        this.lastRunCount = currentRunCount;
+
+        // decide if it is the end of the run
+        if (currentRunCount <= lastRunCount){
+            return;
+        }
+
+
         boolean announce = false;
         this.trackStatistics = track.getTrackStatistics();
         if (trackStatistics.getTotalDistance().greaterThan(nextTotalDistance)) {
@@ -147,6 +159,10 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
         if (!trackStatistics.getTotalTime().minus(nextTotalTime).isNegative()) {
             updateNextDuration();
+            announce = true;
+        }
+
+        if (PreferencesUtils.shouldVoiceAnnounceMaxSpeedRun() && PreferencesUtils.shouldVoiceAnnounceAverageslopeRun()){
             announce = true;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -23,6 +23,7 @@ import android.icu.text.MessageFormat;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.style.TtsSpan;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -160,12 +161,19 @@ class VoiceAnnouncementUtils {
         return builder;
     }
 
+    private static void resetRunData(TrackStatistics trackStatistics){
+        trackStatistics.setMaximumSpeedPerRun(0);
+		trackStatistics.setAverageslopePerRun(0);
+    }
+
     static Spannable createRunStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
         //TODO: Once we get run data from other groups, we can announce run statistics instead of track statistics
         Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
-        Speed maxSpeed = trackStatistics.getMaxSpeed();
+        Float maxSpeed = trackStatistics.getMaximumSpeedPerRun();
+		Float Averageslope = trackStatistics.getAverageslopePerRun();
+        resetRunData(trackStatistics);
         int speedId;
         String unitSpeedTTS;
         switch (unitSystem) {
@@ -195,15 +203,15 @@ class VoiceAnnouncementUtils {
             builder.append(".");
         }
 
-        if (shouldVoiceAnnounceMaxSpeedRun()) {
-            double speedInUnit = maxSpeed.to(unitSystem);
+        if (shouldVoiceAnnounceMaxSpeedRun()&&maxSpeed!=null) {
+            double speedInUnit = maxSpeed;
             builder.append(" ")
                     .append(context.getString(R.string.stats_max_speed));
             String template = context.getResources().getString(speedId);
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
         }
-        if (shouldVoiceAnnounceAverageslopeRun()) {
+        if (shouldVoiceAnnounceAverageslopeRun() && Averageslope!=null) {
             double avgSlope = CalculateAverageSlope();
             if (!Double.isNaN(avgSlope)) {
                 builder.append(" ")

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -40,6 +40,7 @@ import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
 
 class VoiceAnnouncementUtils {
+    private static Double currentMaxSlope;
 
     private VoiceAnnouncementUtils() {
     }
@@ -47,10 +48,10 @@ class VoiceAnnouncementUtils {
 
     static double calculateTimeSkied() {
 
-           return 0.0; 
-		   
+        return 0.0;
+
     }
-	
+
 
     static double calculateMaxSlope() {
 
@@ -63,6 +64,14 @@ class VoiceAnnouncementUtils {
         return 10.0;
     }
 
+    private static double calculateAverageSlope(Distance totalDistance, Float altitudeGain, Float altitudeLoss) {
+        double avgSlope=0;
+        if (totalDistance!=null&&altitudeGain!=null&&altitudeLoss!=null){
+            avgSlope=(altitudeGain+altitudeLoss)/totalDistance.toM()*100;
+        }
+        return  avgSlope;
+    }
+
 
     static Spannable createIdle(Context context) {
         return new SpannableStringBuilder()
@@ -73,6 +82,10 @@ class VoiceAnnouncementUtils {
         SpannableStringBuilder builder = new SpannableStringBuilder();
         Speed maxSpeed = trackStatistics.getMaxSpeed();
         Speed avgSpeed = trackStatistics.getAverageSpeed();
+        Distance totalDistance = trackStatistics.getTotalDistance();
+        Float altitudeGain=trackStatistics.getTotalAltitudeGain();
+        Float altitudeLoss=trackStatistics.getTotalAltitudeLoss();
+
 
         int perUnitStringId;
         int distanceId;
@@ -134,7 +147,7 @@ class VoiceAnnouncementUtils {
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
         }
-		
+
 
         if (shouldVoiceAnnounceTimeSkiedRecording()) {
             double timeSkied = calculateTimeSkied(); // Calculate the maximum slope based on elevation data
@@ -149,7 +162,7 @@ class VoiceAnnouncementUtils {
 
 
         if (shouldVoiceAnnounceAveragesloperecording()) {
-            double avgSlope = CalculateAverageSlope();
+            double avgSlope=calculateAverageSlope(totalDistance,altitudeGain,altitudeLoss);
             if (!Double.isNaN(avgSlope)) {
                 builder.append(" ")
                         .append("Average slope")
@@ -162,17 +175,23 @@ class VoiceAnnouncementUtils {
     }
 
     private static void resetRunData(TrackStatistics trackStatistics){
+        double averageSlope= calculateAverageSlope(trackStatistics.getDistanceRun(),trackStatistics.getAltitudeRun(),0f);
+        if (currentMaxSlope==null || currentMaxSlope<averageSlope){
+            currentMaxSlope=averageSlope;
+        }
         trackStatistics.setMaximumSpeedPerRun(0);
-		trackStatistics.setAverageslopePerRun(0);
+        trackStatistics.setDistanceRun(Distance.of(0));
+        trackStatistics.setAltitudeRun(0f);
     }
 
     static Spannable createRunStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
-        //TODO: Once we get run data from other groups, we can announce run statistics instead of track statistics
         Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
         Float maxSpeed = trackStatistics.getMaximumSpeedPerRun();
-		Float Averageslope = trackStatistics.getAverageslopePerRun();
+        double averageSlope= calculateAverageSlope(trackStatistics.getDistanceRun(),trackStatistics.getAltitudeRun(),0f);
+
+
         resetRunData(trackStatistics);
         int speedId;
         String unitSpeedTTS;
@@ -211,7 +230,7 @@ class VoiceAnnouncementUtils {
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
         }
-        if (shouldVoiceAnnounceAverageslopeRun() && Averageslope!=null) {
+        if (shouldVoiceAnnounceAverageslopeRun()) {
             double avgSlope = CalculateAverageSlope();
             if (!Double.isNaN(avgSlope)) {
                 builder.append(" ")

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -231,7 +231,7 @@ class VoiceAnnouncementUtils {
             builder.append(".");
         }
         if (shouldVoiceAnnounceAverageslopeRun()) {
-            double avgSlope = CalculateAverageSlope();
+            double avgSlope = averageSlope;
             if (!Double.isNaN(avgSlope)) {
                 builder.append(" ")
                         .append("Average slope")

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -57,18 +57,6 @@ class VoiceAnnouncementUtils {
         return maxSlope;
     }
 
-    static double CalculateAverageSlope() {
-        // This is dummy methods to fetch or calculate the average slope.
-        return 10.0;
-    }
-
-    private static double calculateAverageSlope(Distance totalDistance, Float altitudeGain, Float altitudeLoss) {
-        double avgSlope=0;
-        if (totalDistance!=null&&altitudeGain!=null&&altitudeLoss!=null){
-            avgSlope=(altitudeGain+altitudeLoss)/totalDistance.toM()*100;
-        }
-        return  avgSlope;
-    }
 
 
     private static double calculateAverageSlope(Distance totalDistance, Float altitudeGain, Float altitudeLoss) {
@@ -179,8 +167,8 @@ class VoiceAnnouncementUtils {
                 builder.append(" ")
                         .append(context.getString(R.string.settings_announcements_temperature))
                         .append(": ")
-                        .append(String.format("%.2f%%", temperature)) // Format the slope value
-                        .append(".");
+                        .append(String.format("%.2f", temperature)) // Format the slope value
+                        .append(" degree.");
             }
         }
 
@@ -244,7 +232,6 @@ class VoiceAnnouncementUtils {
 
     static Spannable createRunStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
-        Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
         Float maxSpeed = trackStatistics.getMaximumSpeedPerRun();
         double averageSlope= calculateAverageSlope(trackStatistics.getDistanceRun(),trackStatistics.getAltitudeRun(),0f);

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -16,6 +16,8 @@
 
 package de.dennisguse.opentracks.stats;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -68,6 +70,7 @@ public class TrackStatistics {
      private Float slopePercent_m;
      private Float maximumSpeedPerRun;
      private double averageSpeedPerRun;
+	 private Float AverageslopePerRun;
 
 
 
@@ -98,10 +101,12 @@ public class TrackStatistics {
     }
     public void incrementEndOfRunCounter() {
          this.endOfRunCounter++;
+        Log.d("EndCounter", this.endOfRunCounter+"");
     }
 
     public void resetEndOfRunCounter() {
         this.endOfRunCounter = 0;
+        Log.d("EndCounter", "reset counter");
     }
 
     public TrackStatistics() {
@@ -433,11 +438,27 @@ public class TrackStatistics {
          return  slopePercent_m != null;
      }
      public float getMaximumSpeedPerRun() {
-         return maximumSpeedPerRun;
+        Log.d("getSpeed",""+maximumSpeedPerRun);
+        if (maximumSpeedPerRun!=null)
+            return maximumSpeedPerRun;
+        return 0;
      }
 
      public void setMaximumSpeedPerRun(float maximumSpeedPerRun) {
+         Log.d("setSpeed",""+maximumSpeedPerRun);
          this.maximumSpeedPerRun = maximumSpeedPerRun;
+     }
+	 
+	 public float getAverageslopePerRun() {
+        
+        if (AverageslopePerRun!=null)
+            return AverageslopePerRun;
+        return 0;
+     }
+
+     public void setAverageslopePerRun(float AverageslopePerRun) {
+         Log.d("setSlope",""+AverageslopePerRun);
+         this.AverageslopePerRun = AverageslopePerRun;
      }
 
      public double getAverageSpeedPerRun() {

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -66,11 +66,14 @@ public class TrackStatistics {
 
     private boolean isIdle;
 
-     // Slope % between this point and the previous point
-     private Float slopePercent_m;
-     private Float maximumSpeedPerRun;
-     private double averageSpeedPerRun;
-	 private Float AverageslopePerRun;
+    // Slope % between this point and the previous point
+    private Float slopePercent_m;
+    private Float maximumSpeedPerRun;
+    private double averageSpeedPerRun;
+    private Distance distanceRun;
+
+
+    private Float altitudeRun;
 
 
 
@@ -100,7 +103,7 @@ public class TrackStatistics {
         return this.endOfRunCounter;
     }
     public void incrementEndOfRunCounter() {
-         this.endOfRunCounter++;
+        this.endOfRunCounter++;
         Log.d("EndCounter", this.endOfRunCounter+"");
     }
 
@@ -113,29 +116,32 @@ public class TrackStatistics {
         reset();
     }
 
-     /**
-      * Copy constructor.
-      *
-      * @param other another statistics data object to copy from
-      */
-     public TrackStatistics(TrackStatistics other) {
-         startTime = other.startTime;
-         stopTime = other.stopTime;
-         totalDistance = other.totalDistance;
-         totalTime = other.totalTime;
-         movingTime = other.movingTime;
-         maxSpeed = other.maxSpeed;
-         altitudeExtremities.set(other.altitudeExtremities.getMin(), other.altitudeExtremities.getMax());
-         totalAltitudeGain_m = other.totalAltitudeGain_m;
-         totalAltitudeLoss_m = other.totalAltitudeLoss_m;
-         avgHeartRate = other.avgHeartRate;
-         isIdle = other.isIdle;
-         slopePercent_m = other.slopePercent_m;
-         maximumSpeedPerRun = other.maximumSpeedPerRun;
-         averageSpeedPerRun=other.averageSpeedPerRun;
-         totalChairliftWaitingTime=other.totalChairliftWaitingTime;
-         endOfRunCounter=other.endOfRunCounter;
-     }
+    /**
+     * Copy constructor.
+     *
+     * @param other another statistics data object to copy from
+     */
+    public TrackStatistics(TrackStatistics other) {
+        startTime = other.startTime;
+        stopTime = other.stopTime;
+        totalDistance = other.totalDistance;
+        totalTime = other.totalTime;
+        movingTime = other.movingTime;
+        maxSpeed = other.maxSpeed;
+        altitudeExtremities.set(other.altitudeExtremities.getMin(), other.altitudeExtremities.getMax());
+        totalAltitudeGain_m = other.totalAltitudeGain_m;
+        totalAltitudeLoss_m = other.totalAltitudeLoss_m;
+        avgHeartRate = other.avgHeartRate;
+        isIdle = other.isIdle;
+        slopePercent_m = other.slopePercent_m;
+        maximumSpeedPerRun = other.maximumSpeedPerRun;
+        averageSpeedPerRun=other.averageSpeedPerRun;
+        totalChairliftWaitingTime=other.totalChairliftWaitingTime;
+        endOfRunCounter=other.endOfRunCounter;
+        altitudeRun=other.altitudeRun;
+        distanceRun=other.totalDistance;
+
+    }
 
 
     @VisibleForTesting
@@ -210,6 +216,9 @@ public class TrackStatistics {
 
         totalChairliftWaitingTime = totalChairliftWaitingTime.plus(other.totalChairliftWaitingTime);
         endOfRunCounter+= other.endOfRunCounter;
+
+        altitudeRun += other.altitudeRun;
+        distanceRun = distanceRun.plus(other.distanceRun);
     }
 
     public boolean isInitialized() {
@@ -230,6 +239,10 @@ public class TrackStatistics {
 
         setTotalChairliftWaitingTime(Duration.ofSeconds(0));
         resetEndOfRunCounter();
+
+        altitudeRun = 0f;
+        setDistanceRun(Distance.of(0));
+
 
         isIdle = false;
     }
@@ -434,41 +447,56 @@ public class TrackStatistics {
         this.slopePercent_m = slopePercent;
     }
 
-     public boolean hasSlope() {
-         return  slopePercent_m != null;
-     }
-     public float getMaximumSpeedPerRun() {
+    public boolean hasSlope() {
+        return  slopePercent_m != null;
+    }
+    public float getMaximumSpeedPerRun() {
         Log.d("getSpeed",""+maximumSpeedPerRun);
         if (maximumSpeedPerRun!=null)
             return maximumSpeedPerRun;
         return 0;
-     }
+    }
 
-     public void setMaximumSpeedPerRun(float maximumSpeedPerRun) {
-         Log.d("setSpeed",""+maximumSpeedPerRun);
-         this.maximumSpeedPerRun = maximumSpeedPerRun;
-     }
-	 
-	 public float getAverageslopePerRun() {
-        
-        if (AverageslopePerRun!=null)
-            return AverageslopePerRun;
-        return 0;
-     }
+    public void setMaximumSpeedPerRun(float maximumSpeedPerRun) {
+        Log.d("setSpeed",""+maximumSpeedPerRun);
+        this.maximumSpeedPerRun = maximumSpeedPerRun;
+    }
 
-     public void setAverageslopePerRun(float AverageslopePerRun) {
-         Log.d("setSlope",""+AverageslopePerRun);
-         this.AverageslopePerRun = AverageslopePerRun;
-     }
+    public double getAverageSpeedPerRun() {
+        return averageSpeedPerRun;
+    }
 
-     public double getAverageSpeedPerRun() {
-         return averageSpeedPerRun;
-     }
+    public void setAverageSpeedPerRun(double speed) {
+        this.averageSpeedPerRun = speed;
 
-     public void setAverageSpeedPerRun(double speed) {
-         this.averageSpeedPerRun = speed;
+    }
 
-     }
+    public Distance getDistanceRun() {
+        return distanceRun;
+    }
+
+    public void setDistanceRun(Distance distanceRun) {
+        this.distanceRun = distanceRun;
+    }
+
+    public Float getAltitudeRun() {
+        return altitudeRun;
+    }
+
+    public void setAltitudeRun(Float altitudeRun) {
+        this.altitudeRun = altitudeRun;
+    }
+
+    public void addAltitudeRun(float gain_m) {
+        if (altitudeRun == null) {
+            altitudeRun = 0f;
+        }
+        altitudeRun += gain_m;
+    }
+
+    public void addDistanceRun(Distance distance_m) {
+        distanceRun = distanceRun.plus(distance_m);
+    }
 
 
     // Method to calculate the total skiing duration for the current day
@@ -530,17 +558,17 @@ public class TrackStatistics {
         return toString().equals(o.toString());
     }
 
-     @NonNull
-     @Override
-     public String toString() {
-         return "TrackStatistics { Start Time: " + getStartTime() + "; Stop Time: " + getStopTime()
-                 + "; Total Distance: " + getTotalDistance() + "; Total Time: " + getTotalTime()
-                 + "; Moving Time: " + getMovingTime() + "; Max Speed: " + getMaxSpeed()
-                 + "; Maximum Speed Per Run: " + getMaximumSpeedPerRun()
-                 + "; Average Speed Per Run: " + getAverageSpeedPerRun()
-                 + "; Min Altitude: " + getMinAltitude() + "; Max Altitude: " + getMaxAltitude()
-                 + "; Altitude Gain: " + getTotalAltitudeGain()
-                 + "; Altitude Loss: " + getTotalAltitudeLoss()
-                 + "; Slope%: " + getSlopePercent() + "}";
-     }
- }
+    @NonNull
+    @Override
+    public String toString() {
+        return "TrackStatistics { Start Time: " + getStartTime() + "; Stop Time: " + getStopTime()
+                + "; Total Distance: " + getTotalDistance() + "; Total Time: " + getTotalTime()
+                + "; Moving Time: " + getMovingTime() + "; Max Speed: " + getMaxSpeed()
+                + "; Maximum Speed Per Run: " + getMaximumSpeedPerRun()
+                + "; Average Speed Per Run: " + getAverageSpeedPerRun()
+                + "; Min Altitude: " + getMinAltitude() + "; Max Altitude: " + getMaxAltitude()
+                + "; Altitude Gain: " + getTotalAltitudeGain()
+                + "; Altitude Loss: " + getTotalAltitudeLoss()
+                + "; Slope%: " + getSlopePercent() + "}";
+    }
+}


### PR DESCRIPTION
Feature Description:
Added functionality of Average slope announcement at the end of each Run:

Solution:
- added averrage slope function for average slope run in voice_announcements_utils
- added average slope variable for average slope in voice_announcements_utils
- minor fix for average slope reference
- Estimating End of run by slope change per unit distance
- Triggering voice announcement at the end of run

Link to Feature Request:
Issue [#10](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/70)

